### PR TITLE
Fix typo in SeqStrategy documentation

### DIFF
--- a/Control/Parallel/Strategies.hs
+++ b/Control/Parallel/Strategies.hs
@@ -323,7 +323,7 @@ strat2 `dot` strat1 = strat2 . runEval . strat1
 evalSeq :: SeqStrategy a -> Strategy a
 evalSeq strat x = strat x `pseq` return x
 
--- | a name for @Control.Seq.Strategy@, for documetnation only.
+-- | A name for @Control.Seq.Strategy@, for documentation only.
 type SeqStrategy a = Control.Seq.Strategy a
 
 -- --------------------------------------------------------------------------


### PR DESCRIPTION
Fixes typo, and also capitalizes 'a' to be consistent with the rest of the docs.