### PR TITLE
Make rpar's type signature consistent with rseq & co

### DIFF
--- a/Control/Parallel/Strategies.hs
+++ b/Control/Parallel/Strategies.hs
@@ -380,7 +380,7 @@ rdeepseq x = do rseq (rnf x); return x
 -- == rdeepseq
 
 -- | 'rpar' sparks its argument (for evaluation in parallel).
-rpar :: a -> Eval a
+rpar :: Strategy a
 #if __GLASGOW_HASKELL__ >= 702
 rpar  x = Eval $ \s -> spark# x s
 #else


### PR DESCRIPTION
It seems inconsistent that `r0`, `rseq`, `rdeepseq` and `rparWith` are defined using the `Strategy` type synonym, but `rpar` is not. In the [module exports](https://github.com/haskell/parallel/blob/2ee8494e5bb5228a6a878d6e0e0b63316492174c/Control/Parallel/Strategies.hs#L52) it's commented as being of type `Strategy a`, just not in the type signature itself for some reason.