### PR TITLE
tests: Replace python with sh

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,5 +12,5 @@ par003 :
 	@echo Compiling
 	"$(TEST_HC)" -v0 -fforce-recomp --make par003.hs -o par003 -threaded -rtsopts
 	@echo Running
-	$(PYTHON) -c 'for i in range(11111): print "abqszzzq"' | ./par003 +RTS -N2
+	yes abqszzzq 2>/dev/null | head -n 11111 | ./par003 +RTS -N2
 	@echo Done


### PR DESCRIPTION
Python usage is unfortunately rather problematic now since we have the
Python 2/3 split. In this case I'd argue that it's just as easy (if
perhaps less efficient) to just use a shell pipeline.