### PR TITLE
Bump upper bound on base to < 4.13

### DIFF
--- a/parallel.cabal
+++ b/parallel.cabal
@@ -43,7 +43,7 @@ library
 
     build-depends:
         array      >= 0.3 && < 0.6,
-        base       >= 4.3 && < 4.12,
+        base       >= 4.3 && < 4.13,
         containers >= 0.4 && < 0.6,
         deepseq    >= 1.1 && < 1.5
 


### PR DESCRIPTION
See https://ghc.haskell.org/trac/ghc/ticket/15018.