### PR TITLE
Restore rparWith behavior

### DIFF
--- a/tests/all.T
+++ b/tests/all.T
@@ -12,3 +12,6 @@ test('T2185', [when(fast(), skip), reqlib('parallel'),
               only_ways(['threaded1','threaded2'])],
         # threaded1 demonstrates the bug: sparks were treated as roots by GC
         multimod_compile_and_run, ['T2185',''])
+
+test('rparWith_r0', only_ways(['threaded1', 'threaded2']),
+                compile_and_run, ['-package parallel'])

--- a/tests/rparWith_r0.hs
+++ b/tests/rparWith_r0.hs
@@ -1,0 +1,27 @@
+-- | Test if `rparWith r0` has the documented behaviour: to create a spark,
+-- that does nothing. In particular the spark won't evaluate to weak head
+-- normal form (WHNF).
+module Main (main) where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (evaluate)
+import System.IO.Unsafe (unsafePerformIO)
+
+import Control.Parallel.Strategies
+
+data LazyBox a = LazyBox a
+
+main = do
+  -- Create spark, that must *not* evaluate printWhenEvaluated
+  LazyBox printWhenEvaluated <- evaluate $ runEval $ do
+    let printWhenEvaluated = unsafePerformIO $ putStrLn "Must be printed at the end."
+    sparkedResult <- rparWith r0 printWhenEvaluated
+    return $ LazyBox sparkedResult
+
+  -- Give the run time system enough time to evaluate the spark (~0.1s)
+  threadDelay $ 10^5
+
+  putStrLn "Must be printed first."
+
+  -- Finally evaluate printWhenEvaluated
+  evaluate printWhenEvaluated

--- a/tests/rparWith_r0.stdout
+++ b/tests/rparWith_r0.stdout
@@ -1,0 +1,2 @@
+Must be printed first.
+Must be printed at the end.


### PR DESCRIPTION
* Lift the result to avoid always reducing to WHNF.
* Rewrite the documentation of `rparWith`.

Fixes #35